### PR TITLE
fix minor bug

### DIFF
--- a/pkl_to_results.py
+++ b/pkl_to_results.py
@@ -27,7 +27,7 @@ def accuracy(output, target, topk=(1,)):
     correct = pred.eq(target.view(1, -1).expand_as(pred))
     res = []
     for k in topk:
-         correct_k = correct[:k].view(-1).float().sum(0)
+         correct_k = correct[:k].reshape(-1).float().sum(0)
          res.append(correct_k.mul_(100.0 / batch_size))
     return res
 


### PR DESCRIPTION
On running _pkl_to_results.py_ an error showed up:
```
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces)
```
This was fixed by changing the view() function to reshape() in line 30 according to the issue [here](https://github.com/cezannec/capsule_net_pytorch/issues/4).